### PR TITLE
added style for figcaption

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -231,9 +231,16 @@
     max-width: 100%;
 }
 
-.post-content img {
+.post-content {
     border-radius: 4px;
     margin: 1rem 0;
+}
+
+/*  Had to make this change so the images have a smaller bottom margin. 
+    This would allow me to position the caption closer to the image*/
+img {
+    border-radius: 4px;
+    margin: 1rem 0 0.1rem 0;
 }
 
 .post-content img[src*="#center"] {

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,1 +1,8 @@
-<img loading="lazy" src="{{ .Destination | safeURL }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}" {{ end }} />
+{{ if .Title }}
+  <figure>
+    <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}">
+    <figcaption style ="margin: auto; font-style: italic; font-size: x-small; color: rgb(168, 151, 151); text-align: center; width: 80%; padding: 10px;">{{ .Title }}</figcaption>
+  </figure>
+{{ else }}
+  <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}">
+{{ end }}


### PR DESCRIPTION
- added gray caption for images
- set `margin`'s bottom to `0` so the caption would be closer to the image. 